### PR TITLE
support for post command

### DIFF
--- a/base-template/templates/_environment.yaml
+++ b/base-template/templates/_environment.yaml
@@ -1,6 +1,6 @@
 {{- define "base-template.environment" -}}
 {{- range $key, $value := .Values.env }}
       {{ $key }}: {{ $value | quote }}
-{{ end }}
-{{ end }}
+{{- end }}
+{{- end }}
 

--- a/base-template/templates/_flux-minicluster.yaml
+++ b/base-template/templates/_flux-minicluster.yaml
@@ -36,9 +36,12 @@ spec:
          for i in $(seq 1 {{ default 1 .Values.experiment.iterations }})
          do
            echo "Running iteration \${i}"
-           cmd='flux run -N{{ if .Values.experiment.nodes }}{{ .Values.experiment.nodes }}{{ else }}1{{ end }} {{ if .Values.experiment.tasks }}-n {{ .Values.experiment.tasks }}{{ end }} -o cpu-affinity={{ default "per-task" .Values.experiment.cpu_affinity }} -o gpu-affinity={{ default "off" .Values.experiment.gpu_affinity }} {{ if .Values.experiment.run_threads }}--env OMP_NUM_THREADS={{ .Values.experiment.run_threads }}{{ end }} {{ if .Values.experiment.cores_per_task }}--cores-per-task {{ .Values.experiment.cores_per_task }}{{ end }} {{ if .Values.experiment.exclusive }}--exclusive{{ end }} ${apprun}'
+           cmd='flux run --setattr=user.study_id=${app}-iter-${i} -N{{ if .Values.experiment.nodes }}{{ .Values.experiment.nodes }}{{ else }}1{{ end }} {{ if .Values.experiment.tasks }}-n {{ .Values.experiment.tasks }}{{ end }} -o cpu-affinity={{ default "per-task" .Values.experiment.cpu_affinity }} -o gpu-affinity={{ default "off" .Values.experiment.gpu_affinity }} {{ if .Values.experiment.run_threads }}--env OMP_NUM_THREADS={{ .Values.experiment.run_threads }}{{ end }} {{ if .Values.experiment.cores_per_task }}--cores-per-task {{ .Values.experiment.cores_per_task }}{{ end }} {{ if .Values.experiment.exclusive }}--exclusive{{ end }} ${apprun}'
            \$cmd >> /tmp/${app}.out
          done
+         {{- if .Values.minicluster.commands_post }}{{- range $k, $v := .Values.minicluster.commands_post }}
+           {{ . | toYaml | indent 4 | trim }}
+         {{- end }}{{- end }}
          EOF
          cat /tmp/run_${app}.sh
 {{ end }}


### PR DESCRIPTION
to get flux metadata (and other actions we need post commands). This adds them. The user can add the minicluster.commands_post (a list) to add them.

I am also automatically annotating each submission with the app and iteration.