### PR TITLE
feat: add gpu support

### DIFF
--- a/amg2023/values.yaml
+++ b/amg2023/values.yaml
@@ -28,13 +28,13 @@ minicluster:
 
   # Interactive MiniCluster?
   interactive: false
+
+  # Number of NVIDIA gpus
+  gpus: 0
   
   # MiniCluster size
   size: 1
   
-  # Minicluster tasks
-  tasks: 8
-
   # Add flux on the fly (set to false if Flux is already in the container)
   addFlux: false
   

--- a/base-template/templates/_flux-minicluster.yaml
+++ b/base-template/templates/_flux-minicluster.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   size: {{ default 1 .Values.minicluster.size }}
   {{ if .Values.minicluster.interactive }}interactive: true {{ end }}
-  {{ if .Values.minicluster.tasks }}tasks: {{ .Values.minicluster.tasks }}{{ end }}
 
   logging:
     quiet: {{ if .Values.logging.quiet }}true{{ else }}false{{ end }}
@@ -24,6 +23,9 @@ spec:
     launcher: true
     securityContext:
       privileged: {{ if .Values.minicluster.privileged }}true{{ else }}false{{ end }}
+    resources:
+      limits:
+        nvidia.com/gpu: "{{ .Values.minicluster.gpus }}"
     commands:
       {{ if .Values.minicluster.commands_init }}init: {{ .Values.minicluster.commands_init }}{{ end }}
       post: |
@@ -33,6 +35,11 @@ spec:
         {{- end }}{{- end }}
 
       pre: |
+         {{ if .Values.minicluster.gpus }}procs=$(nproc); procs=$((procs - 1));   
+         gpus={{ .Values.minicluster.gpus }}; gpus=$((gpus - 1)); {{ $gpus := (.Values.minicluster.gpus | int) }}
+         {{ $gpus := (subf $gpus 1 | int) }}flux R encode --hosts=${hosts} --cores=0-${procs} --gpu=0-${gpus} > ${viewroot}/etc/flux/system/R
+         cat ${viewroot}/etc/flux/system/R
+         export CUDA_VISIBLE_DEVICES=0{{ range untilStep 1 $gpus 1 }},{{ . }}{{ end }}{{ end }}
          cat <<EOF >> /tmp/run_${app}.sh
          #!/bin/bash
          set -euo pipefail

--- a/kripke/values.yaml
+++ b/kripke/values.yaml
@@ -38,8 +38,8 @@ minicluster:
   # MiniCluster size
   size: 1
   
-  # Minicluster tasks
-  tasks: 8
+  # Number of NVIDIA gpus
+  gpus: 0
 
   # Add flux on the fly (set to false if Flux is already in the container)
   addFlux: false

--- a/laghos/values.yaml
+++ b/laghos/values.yaml
@@ -45,8 +45,8 @@ minicluster:
   # MiniCluster size
   size: 1
   
-  # Minicluster tasks
-  tasks: 8
+  # Number of NVIDIA gpus
+  gpus: 0
 
   # Add flux on the fly (set to false if Flux is already in the container)
   addFlux: false

--- a/lammps-reax/values.yaml
+++ b/lammps-reax/values.yaml
@@ -31,8 +31,8 @@ minicluster:
   # MiniCluster size
   size: 1
   
-  # Minicluster tasks
-  tasks: 2
+  # Number of NVIDIA gpus
+  gpus: 0
 
   # Add flux on the fly (set to false if Flux is already in the container)
   addFlux: false

--- a/minife/values.yaml
+++ b/minife/values.yaml
@@ -36,8 +36,8 @@ minicluster:
   # MiniCluster size
   size: 1
   
-  # Minicluster tasks
-  tasks: 8
+  # Number of NVIDIA gpus
+  gpus: 0
 
   # Add flux on the fly (set to false if Flux is already in the container)
   addFlux: false

--- a/mixbench/values.yaml
+++ b/mixbench/values.yaml
@@ -30,8 +30,8 @@ minicluster:
   # MiniCluster size
   size: 1
   
-  # Minicluster tasks
-  tasks: 8
+  # Number of NVIDIA gpus
+  gpus: 0
 
   # Add flux on the fly (set to false if Flux is already in the container)
   addFlux: false

--- a/mt-gemm/values.yaml
+++ b/mt-gemm/values.yaml
@@ -29,8 +29,8 @@ minicluster:
   # MiniCluster size
   size: 1
   
-  # Minicluster tasks
-  tasks: 2
+  # Number of NVIDIA gpus
+  gpus: 0
 
   # Add flux on the fly (set to false if Flux is already in the container)
   addFlux: false

--- a/osu-benchmarks/values.yaml
+++ b/osu-benchmarks/values.yaml
@@ -30,8 +30,8 @@ minicluster:
   # MiniCluster size
   size: 1
   
-  # Minicluster tasks
-  tasks: 8
+  # Number of NVIDIA gpus
+  gpus: 0
 
   # Add flux on the fly (set to false if Flux is already in the container)
   addFlux: false

--- a/quicksilver/values.yaml
+++ b/quicksilver/values.yaml
@@ -43,8 +43,8 @@ minicluster:
   # MiniCluster size
   size: 1
   
-  # Minicluster tasks
-  tasks: 8
+  # Number of NVIDIA gpus
+  gpus: 0
 
   # Add flux on the fly (set to false if Flux is already in the container)
   addFlux: false

--- a/single-node/values.yaml
+++ b/single-node/values.yaml
@@ -29,8 +29,8 @@ minicluster:
   # MiniCluster size
   size: 1
   
-  # Minicluster tasks
-  tasks: 8
+  # Number of NVIDIA gpus
+  gpus: 0
 
   # Add flux on the fly (set to false if Flux is already in the container)
   addFlux: false

--- a/stream/values.yaml
+++ b/stream/values.yaml
@@ -29,8 +29,8 @@ minicluster:
   # MiniCluster size
   size: 1
   
-  # Minicluster tasks
-  tasks: 8
+  # Number of NVIDIA gpus
+  gpus: 0
 
   # Add flux on the fly (set to false if Flux is already in the container)
   addFlux: false


### PR DESCRIPTION
We want to be able to easily add GPU to any of these templates. Further, the definition of the minicluster tasks is not needed since the commands to launch / run tasks are generated by us.

Currently, support to get logs and push to oras is provided in an example. I'm still thinking through if there should be something akin to "snippets" that can be enabled (akin to oras) or just the ability to print the same info after the job has run. That would be easy enough to parse... the reason oras might be needed is for additional output files / data that is larger.